### PR TITLE
Issues/24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v0.7
 
+### v0.7.6 (05/28/2020)
+-   Fix typo in `http.throttler.catchup.interval.millis` configuration property
+
 ### v0.7.5 (05/27/2020)
 -   Fix https://github.com/castorm/kafka-connect-http/issues/22: build fails with jdk 11
 -   Simplify `SchemedKvSourceRecordMapper` by removing irrelevant configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### v0.7.6 (05/28/2020)
 -   Fix typo in `http.throttler.catchup.interval.millis` configuration property
+-   Change default polling interval to 60s and 30s when catching up
 
 ### v0.7.5 (05/27/2020)
 -   Fix https://github.com/castorm/kafka-connect-http/issues/22: build fails with jdk 11

--- a/src/main/java/com/github/castorm/kafka/connect/throttle/AdaptableIntervalThrottlerConfig.java
+++ b/src/main/java/com/github/castorm/kafka/connect/throttle/AdaptableIntervalThrottlerConfig.java
@@ -57,7 +57,7 @@ public class AdaptableIntervalThrottlerConfig extends AbstractConfig {
 
     public static ConfigDef config() {
         return new ConfigDef()
-                .define(TAIL_INTERVAL_MILLIS, LONG, 10000L, HIGH, "Throttle Tail Interval Millis")
-                .define(CATCHUP_INTERVAL_MILLIS, LONG, 1000L, HIGH, "Throttle Catchup Interval Millis");
+                .define(TAIL_INTERVAL_MILLIS, LONG, 60000L, HIGH, "Throttle Tail Interval Millis")
+                .define(CATCHUP_INTERVAL_MILLIS, LONG, 30000L, HIGH, "Throttle Catchup Interval Millis");
     }
 }

--- a/src/main/java/com/github/castorm/kafka/connect/throttle/AdaptableIntervalThrottlerConfig.java
+++ b/src/main/java/com/github/castorm/kafka/connect/throttle/AdaptableIntervalThrottlerConfig.java
@@ -36,7 +36,7 @@ import static org.apache.kafka.common.config.ConfigDef.Type.LONG;
 public class AdaptableIntervalThrottlerConfig extends AbstractConfig {
 
     private static final String TAIL_INTERVAL_MILLIS = "http.throttler.interval.millis";
-    private static final String CATCHUP_INTERVAL_MILLIS = "http.throttle.catchup.interval.millis";
+    private static final String CATCHUP_INTERVAL_MILLIS = "http.throttler.catchup.interval.millis";
 
     private final FixedIntervalThrottler tailThrottler;
     private final FixedIntervalThrottler catchupThrottler;

--- a/src/test/java/com/github/castorm/kafka/connect/throttle/AdaptableIntervalThrottlerConfigTest.java
+++ b/src/test/java/com/github/castorm/kafka/connect/throttle/AdaptableIntervalThrottlerConfigTest.java
@@ -32,7 +32,7 @@ class AdaptableIntervalThrottlerConfigTest {
 
     @Test
     void whenTailIntervalMillis_thenDefault() {
-        assertThat(config(emptyMap()).getTailThrottler().getIntervalMillis()).isEqualTo(10000L);
+        assertThat(config(emptyMap()).getTailThrottler().getIntervalMillis()).isEqualTo(60000L);
     }
 
     @Test
@@ -42,7 +42,7 @@ class AdaptableIntervalThrottlerConfigTest {
 
     @Test
     void whenCatchupIntervalMillis_thenDefault() {
-        assertThat(config(emptyMap()).getCatchupThrottler().getIntervalMillis()).isEqualTo(1000L);
+        assertThat(config(emptyMap()).getCatchupThrottler().getIntervalMillis()).isEqualTo(30000L);
     }
 
     @Test

--- a/src/test/java/com/github/castorm/kafka/connect/throttle/AdaptableIntervalThrottlerConfigTest.java
+++ b/src/test/java/com/github/castorm/kafka/connect/throttle/AdaptableIntervalThrottlerConfigTest.java
@@ -47,7 +47,7 @@ class AdaptableIntervalThrottlerConfigTest {
 
     @Test
     void whenCatchupIntervalMillis_thenInitialized() {
-        assertThat(config(ImmutableMap.of("http.throttle.catchup.interval.millis", "73")).getCatchupThrottler().getIntervalMillis()).isEqualTo(73L);
+        assertThat(config(ImmutableMap.of("http.throttler.catchup.interval.millis", "73")).getCatchupThrottler().getIntervalMillis()).isEqualTo(73L);
     }
 
     private static AdaptableIntervalThrottlerConfig config(Map<String, Object> settings) {

--- a/src/test/java/com/github/castorm/kafka/connect/throttle/FixedIntervalThrottlerTest.java
+++ b/src/test/java/com/github/castorm/kafka/connect/throttle/FixedIntervalThrottlerTest.java
@@ -35,6 +35,7 @@ import java.util.function.Supplier;
 
 import static com.github.castorm.kafka.connect.throttle.FixedIntervalThrottlerTest.Fixture.intervalMillis;
 import static com.github.castorm.kafka.connect.throttle.FixedIntervalThrottlerTest.Fixture.lastPollMillis;
+import static com.github.castorm.kafka.connect.throttle.FixedIntervalThrottlerTest.Fixture.maxExecutionTimeMillis;
 import static com.github.castorm.kafka.connect.throttle.FixedIntervalThrottlerTest.Fixture.offset;
 import static java.time.Instant.now;
 import static java.util.Collections.emptyMap;
@@ -74,7 +75,7 @@ class FixedIntervalThrottlerTest {
 
         then(sleeper).should().sleep(sleepMillis.capture());
 
-        assertThat(sleepMillis.getValue()).isCloseTo(intervalMillis, offset(intervalMillis / 10));
+        assertThat(sleepMillis.getValue()).isCloseTo(intervalMillis, offset(maxExecutionTimeMillis));
     }
 
     @Test
@@ -97,7 +98,8 @@ class FixedIntervalThrottlerTest {
 
     interface Fixture {
         Offset offset = Offset.of(emptyMap(), "key", now());
-        long intervalMillis = 60000L;
+        long intervalMillis = 300000L;
         long lastPollMillis = System.currentTimeMillis();
+        long maxExecutionTimeMillis = 500L;
     }
 }


### PR DESCRIPTION
-   Fix typo in `http.throttler.catchup.interval.millis` configuration property
-   Change default polling interval to 60s and 30s when catching up