### PR TITLE
Handle records committed out of order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v0.8
 
-### v0.8.2 (11/16/2020)
+### v0.8.5 (11/16/2020)
 -   Handle records committed out of order
 
 ### v0.8.1 (11/09/2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v0.8
 
+### v0.8.2 (11/16/2020)
+-   Handle records committed out of order
+
 ### v0.8.1 (11/09/2020)
 -   Project restructured to enable integration testing
 
@@ -13,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   Provided different log levels for `OkHttpClient`.`TRACE`: `BODY`, `DEBUG`: `BASIC`, `*`: `NONE`
 -   Refactored throttler adding the notion of timer
 -   Support for authentication extension. Initial implementations for None and Basic authentication types
+
+## v0.7
 
 ### v0.7.6 (05/28/2020)
 -   Fix typo in `http.throttler.catchup.interval.millis` configuration property

--- a/kafka-connect-http-test/src/test/java/com/github/castorm/kafka/connect/ConnectorUtils.java
+++ b/kafka-connect-http-test/src/test/java/com/github/castorm/kafka/connect/ConnectorUtils.java
@@ -91,9 +91,7 @@ public class ConnectorUtils {
         List<SourceRecord> records;
         do {
             records = task.poll();
-            for (SourceRecord record : records) {
-                task.commitRecord(record, null);
-            }
+            records.forEach(record -> task.commitRecord(record, null));
             task.commit();
             allRecords.addAll(records);
         } while (!records.isEmpty());

--- a/kafka-connect-http-test/src/test/java/com/github/castorm/kafka/connect/ConnectorUtils.java
+++ b/kafka-connect-http-test/src/test/java/com/github/castorm/kafka/connect/ConnectorUtils.java
@@ -91,7 +91,10 @@ public class ConnectorUtils {
         List<SourceRecord> records;
         do {
             records = task.poll();
-            records.forEach(task::commitRecord);
+            for (SourceRecord record : records) {
+                task.commitRecord(record, null);
+            }
+            task.commit();
             allRecords.addAll(records);
         } while (!records.isEmpty());
         task.stop();

--- a/kafka-connect-http/pom.xml
+++ b/kafka-connect-http/pom.xml
@@ -94,7 +94,7 @@
                                     <finalName>${project.groupId}-${project.artifactId}-${project.version}</finalName>
                                     <appendAssemblyId>false</appendAssemblyId>
                                     <descriptors>
-                                        <descriptor>kafka-connect-http/src/assembly/package.xml</descriptor>
+                                        <descriptor>src/assembly/package.xml</descriptor>
                                     </descriptors>
                                 </configuration>
                             </execution>
@@ -110,7 +110,7 @@
                                     </formats>
                                     <tarLongFileMode>posix</tarLongFileMode>
                                     <descriptors>
-                                        <descriptor>kafka-connect-http/src/assembly/plugin.xml</descriptor>
+                                        <descriptor>src/assembly/plugin.xml</descriptor>
                                     </descriptors>
                                 </configuration>
                             </execution>

--- a/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/common/CollectorsUtils.java
+++ b/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/common/CollectorsUtils.java
@@ -1,0 +1,47 @@
+package com.github.castorm.kafka.connect.common;
+
+/*-
+ * #%L
+ * kafka-connect-http
+ * %%
+ * Copyright (C) 2020 CastorM
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import lombok.experimental.UtilityClass;
+
+import java.util.LinkedHashMap;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+@UtilityClass
+public class CollectorsUtils {
+
+  public static <T, K, U> Collector<T, ?, LinkedHashMap<K,U>> toLinkedHashMap(
+      Function<? super T, ? extends K> keyMapper,
+      Function<? super T, ? extends U> valueMapper)
+  {
+    return Collectors.toMap(
+        keyMapper,
+        valueMapper,
+        (u, v) -> {
+          throw new IllegalStateException(String.format("Duplicate key %s", u));
+        },
+        LinkedHashMap::new
+    );
+  }
+
+}

--- a/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/ConfirmationWindow.java
+++ b/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/ConfirmationWindow.java
@@ -1,0 +1,65 @@
+package com.github.castorm.kafka.connect.http;
+
+/*-
+ * #%L
+ * kafka-connect-http
+ * %%
+ * Copyright (C) 2020 CastorM
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static com.github.castorm.kafka.connect.common.CollectorsUtils.toLinkedHashMap;
+
+@Slf4j
+public class ConfirmationWindow<T> {
+
+    private final LinkedHashMap<T, Boolean> confirmedOffsets;
+
+    public ConfirmationWindow(List<T> offsets) {
+        confirmedOffsets = offsets.stream()
+            .collect(toLinkedHashMap(Function.identity(), __ -> false));
+    }
+
+    public void confirm(T offset) {
+        confirmedOffsets.replace(offset, true);
+
+        log.debug("Confirmed offset {}", offset);
+    }
+
+    public T getLowWatermarkOffset() {
+        T offset = null;
+        for (Map.Entry<T, Boolean> offsetEntry : confirmedOffsets.entrySet()) {
+            final Boolean offsetWasConfirmed = offsetEntry.getValue();
+            final T sourceOffset = offsetEntry.getKey();
+            if (offsetWasConfirmed) {
+                offset = sourceOffset;
+            } else {
+                log.warn("Found unconfirmed offset {}. Will resume polling from previous offset. " +
+                    "This might result in a number of duplicated records.", sourceOffset);
+
+                break;
+            }
+        }
+
+        return offset;
+    }
+}

--- a/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/HttpSourceTask.java
+++ b/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/HttpSourceTask.java
@@ -128,14 +128,14 @@ public class HttpSourceTask extends SourceTask {
     }
 
     @Override
-    public void commitRecord(SourceRecord record, RecordMetadata metadata) throws InterruptedException {
+    public void commitRecord(SourceRecord record, RecordMetadata metadata) {
         committedOffsets.replace(record.sourceOffset(), true);
 
         log.debug("Committed offset {}", record.sourceOffset());
     }
 
     @Override
-    public void commit() throws InterruptedException {
+    public void commit() {
         Map<String, ?> newOffset = null;
         for (Map.Entry<Map<String, ?>, Boolean> offsetEntry : committedOffsets.entrySet()) {
             final Boolean offsetWasCommitted = offsetEntry.getValue();

--- a/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/request/template/TemplateHttpRequestFactoryConfig.java
+++ b/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/request/template/TemplateHttpRequestFactoryConfig.java
@@ -20,7 +20,7 @@ package com.github.castorm.kafka.connect.http.request.template;
  * #L%
  */
 
-import com.github.castorm.kafka.connect.http.request.template.freemarker.FreeMarkerTemplateFactory;
+import com.github.castorm.kafka.connect.http.request.template.freemarker.BackwardsCompatibleFreeMarkerTemplateFactory;
 import com.github.castorm.kafka.connect.http.request.template.spi.TemplateFactory;
 import lombok.Getter;
 import org.apache.kafka.common.config.AbstractConfig;
@@ -73,6 +73,6 @@ public class TemplateHttpRequestFactoryConfig extends AbstractConfig {
                 .define(HEADERS, STRING, "", MEDIUM, "HTTP Headers Template")
                 .define(QUERY_PARAMS, STRING, "", MEDIUM, "HTTP Query Params Template")
                 .define(BODY, STRING, "", LOW, "HTTP Body Template")
-                .define(TEMPLATE_FACTORY, CLASS, FreeMarkerTemplateFactory.class, LOW, "Template Factory Class");
+                .define(TEMPLATE_FACTORY, CLASS, BackwardsCompatibleFreeMarkerTemplateFactory.class, LOW, "Template Factory Class");
     }
 }

--- a/kafka-connect-http/src/test/java/com/github/castorm/kafka/connect/http/ConfirmationWindowTest.java
+++ b/kafka-connect-http/src/test/java/com/github/castorm/kafka/connect/http/ConfirmationWindowTest.java
@@ -1,0 +1,107 @@
+package com.github.castorm.kafka.connect.http;
+
+/*-
+ * #%L
+ * kafka-connect-http
+ * %%
+ * Copyright (C) 2020 CastorM
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+
+import static com.github.castorm.kafka.connect.http.ConfirmationWindowTest.Fixture.offsetMap;
+import static java.time.Instant.now;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConfirmationWindowTest {
+
+    @Test
+    void givenConfirmationWindowInitializedWithNoOffsets_whenNoOffsetConfirmed_thenNullIsReturned() {
+        final ConfirmationWindow<Map<String, Object>> confirmationWindow =
+            new ConfirmationWindow<>(Collections.emptyList());
+
+        assertThat(confirmationWindow.getLowWatermarkOffset()).isEqualTo(null);
+    }
+
+    @Test
+    void givenConfirmationWindowInitializedWithOffsets_whenNoOffsetConfirmed_thenNullIsReturned() {
+        final ConfirmationWindow<Map<String, Object>> confirmationWindow =
+            new ConfirmationWindow<>(asList(offsetMap(1), offsetMap(2), offsetMap(3)));
+
+        assertThat(confirmationWindow.getLowWatermarkOffset()).isEqualTo(null);
+    }
+
+    @Test
+    void givenConfirmationWindowInitializedWithOffsets_whenAllOffsetsConfirmed_thenLastOffsetIsReturned() {
+        final ConfirmationWindow<Map<String, Object>> confirmationWindow =
+            new ConfirmationWindow<>(asList(offsetMap(1), offsetMap(2), offsetMap(3)));
+
+        confirmationWindow.confirm(offsetMap(1));
+        confirmationWindow.confirm(offsetMap(2));
+        confirmationWindow.confirm(offsetMap(3));
+
+        assertThat(confirmationWindow.getLowWatermarkOffset()).isEqualTo(offsetMap(3));
+    }
+
+    @Test
+    void givenConfirmationWindowInitializedWithOffsets_whenAllOffsetsConfirmedOutOfOrder_thenLastOffsetIsReturned() {
+        final ConfirmationWindow<Map<String, Object>> confirmationWindow =
+            new ConfirmationWindow<>(asList(offsetMap(1), offsetMap(2), offsetMap(3)));
+
+        confirmationWindow.confirm(offsetMap(2));
+        confirmationWindow.confirm(offsetMap(3));
+        confirmationWindow.confirm(offsetMap(1));
+
+        assertThat(confirmationWindow.getLowWatermarkOffset()).isEqualTo(offsetMap(3));
+    }
+
+    @Test
+    void givenConfirmationWindowInitializedWithOffsets_whenFirstOffsetsNotConfirmed_thenNullIsReturned() {
+        final ConfirmationWindow<Map<String, Object>> confirmationWindow =
+            new ConfirmationWindow<>(asList(offsetMap(1), offsetMap(2), offsetMap(3)));
+
+        confirmationWindow.confirm(offsetMap(2));
+        confirmationWindow.confirm(offsetMap(3));
+
+        assertThat(confirmationWindow.getLowWatermarkOffset()).isEqualTo(null);
+    }
+
+    @Test
+    void givenConfirmationWindowInitializedWithOffsets_whenSecondOffsetsNotConfirmed_thenFirstOffsetIsReturned() {
+        final ConfirmationWindow<Map<String, Object>> confirmationWindow =
+            new ConfirmationWindow<>(asList(offsetMap(1), offsetMap(2), offsetMap(3)));
+
+        confirmationWindow.confirm(offsetMap(1));
+        confirmationWindow.confirm(offsetMap(3));
+
+        assertThat(confirmationWindow.getLowWatermarkOffset()).isEqualTo(offsetMap(1));
+    }
+
+    interface Fixture {
+        Instant now = now();
+        String key = "customKey";
+
+        static Map<String, Object> offsetMap(Object value) {
+            return ImmutableMap.of("custom", value, "key", key, "timestamp", now.toString());
+        }
+    }
+}

--- a/kafka-connect-http/src/test/java/com/github/castorm/kafka/connect/http/request/template/TemplateHttpRequestFactoryConfigTest.java
+++ b/kafka-connect-http/src/test/java/com/github/castorm/kafka/connect/http/request/template/TemplateHttpRequestFactoryConfigTest.java
@@ -20,7 +20,7 @@ package com.github.castorm.kafka.connect.http.request.template;
  * #L%
  */
 
-import com.github.castorm.kafka.connect.http.request.template.freemarker.FreeMarkerTemplateFactory;
+import com.github.castorm.kafka.connect.http.request.template.freemarker.BackwardsCompatibleFreeMarkerTemplateFactory;
 import com.github.castorm.kafka.connect.http.request.template.spi.Template;
 import com.github.castorm.kafka.connect.http.request.template.spi.TemplateFactory;
 import org.apache.kafka.common.config.ConfigException;
@@ -90,7 +90,7 @@ class TemplateHttpRequestFactoryConfigTest {
 
     @Test
     void whenMissingTemplateFactory_thenDefault() {
-        assertThat(configWithout("http.request.template.factory").getTemplateFactory()).isInstanceOf(FreeMarkerTemplateFactory.class);
+        assertThat(configWithout("http.request.template.factory").getTemplateFactory()).isInstanceOf(BackwardsCompatibleFreeMarkerTemplateFactory.class);
     }
 
     @Test


### PR DESCRIPTION
Because the order in which records are committed is only guaranteed for records being sent to the same partition, when a topic has more than 1 partition, records may be committed out of order. This resulted in duplicated records as the next `poll()` would start from an "earlier" offset.

This PR aims to handle such cases by storing the offsets of the records sent to KC in a [LinkedHashMap<K,V>](https://docs.oracle.com/javase/8/docs/api/java/util/LinkedHashMap.html). (This data structure is particularly well suited because it (1) keeps the keys in order and (2) provides O(1) performance for modifications.) This map is updated as records are committed. When the whole batch has been committed (call to `commit()`), the (current) offset will be set to either the offset before a non-committed record, or the last one if all were committed. This will ensure at-least-once delivery guarantees.

Additionally, 2 other (unrelated) modifications were made:
- use `BackwardsCompatibleFreeMarkerTemplateFactory` as the default template factory to align with the documentation;
- update the path to the `descriptor` files of the `maven-assembly-plugin` in `kafka-connect-http/pom.xml`.

If you think those modifications don't belong in this PR, I'll gladly remove them.