### PR TITLE
Make format of offset.timestamp as ISO8601 explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,12 +214,16 @@ This `HttpRequestFactory` is based on template resolution.
 FreeMarker templates will have the following data model available:
 *   offset
     *   key
-    *   timestamp
+    *   timestamp (as ISO8601 string, e.g.: `2020-01-01T00:00:00Z`)
     *   ... _(custom offset properties)_
 
 Accessing any of the above withing a template can be achieved like this:
 ```properties
 http.request.params=after=${offset.timestamp}
+```
+For an Epoch representation of the same string, FreeMarker built-ins should be used:
+```properties
+http.request.params=after=${offset.timestamp?datetime.iso?long}
 ```
 For a complete understanding of the features provided by FreeMarker, please, refer to the 
 [User Manual](https://freemarker.apache.org/docs/index.html)

--- a/examples/elasticsearch-search.md
+++ b/examples/elasticsearch-search.md
@@ -57,11 +57,11 @@ queries.
     "config": {
         "connector.class": "com.github.castorm.kafka.connect.http.HttpSourceConnector",
         "tasks.max": "1",
-        "http.offset.initial": "timestamp=1589500805994",
+        "http.offset.initial": "timestamp=2020-01-01T00:00:00Z",
         "http.request.url": "http://domain/index_name/_search",
         "http.request.method": "POST",
         "http.request.headers": "Content-Type: application/json",
-        "http.request.body": "{\"size\": 100, \"sort\": [{\"@timestamp\": \"asc\"}], \"search_after\": [${offset.timestamp}]}",
+        "http.request.body": "{\"size\": 100, \"sort\": [{\"@timestamp\": \"asc\"}], \"search_after\": [${offset.timestamp?datetime.iso?long}]}",
         "http.response.list.pointer": "/hits/hits",
         "http.response.record.pointer": "/_source",
         "http.response.record.key.pointer": "/_id",

--- a/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/request/template/freemarker/BackwardsCompatibleFreeMarkerTemplateFactory.java
+++ b/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/request/template/freemarker/BackwardsCompatibleFreeMarkerTemplateFactory.java
@@ -40,7 +40,9 @@ import static java.util.UUID.randomUUID;
 @Deprecated
 public class BackwardsCompatibleFreeMarkerTemplateFactory implements TemplateFactory {
 
-    private final Configuration configuration = new Configuration(new Version(2, 3, 30));
+    private final Configuration configuration = new Configuration(new Version(2, 3, 30)) {{
+        setNumberFormat("computer");
+    }};
 
     @Override
     public Template create(String template) {

--- a/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/request/template/freemarker/FreeMarkerTemplateFactory.java
+++ b/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/request/template/freemarker/FreeMarkerTemplateFactory.java
@@ -38,7 +38,9 @@ import static java.util.UUID.randomUUID;
 
 public class FreeMarkerTemplateFactory implements TemplateFactory {
 
-    private final Configuration configuration = new Configuration(new Version(2, 3, 30));
+    private final Configuration configuration = new Configuration(new Version(2, 3, 30)) {{
+        setNumberFormat("computer");
+    }};
 
     @Override
     public Template create(String template) {

--- a/kafka-connect-http/src/test/java/com/github/castorm/kafka/connect/http/request/template/freemarker/BackwardsCompatibleFreeMarkerTemplateFactoryTest.java
+++ b/kafka-connect-http/src/test/java/com/github/castorm/kafka/connect/http/request/template/freemarker/BackwardsCompatibleFreeMarkerTemplateFactoryTest.java
@@ -24,6 +24,8 @@ import com.github.castorm.kafka.connect.http.model.Offset;
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
+
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,5 +48,17 @@ class BackwardsCompatibleFreeMarkerTemplateFactoryTest {
     void givenTemplate_whenApplyOffsetValue_thenReplacedWithoutNamespace() {
         Offset offset = Offset.of(ImmutableMap.of("key", "offset1"));
         assertThat(factory.create("template ${key}").apply(offset)).isEqualTo("template offset1");
+    }
+
+    @Test
+    void givenTemplateWithTimestampAsString_whenApplyValue_thenReplaced() {
+        Offset offset = Offset.of(ImmutableMap.of("timestamp", Instant.parse("2020-01-01T00:00:00Z")));
+        assertThat(factory.create("${offset.timestamp}").apply(offset)).isEqualTo("2020-01-01T00:00:00Z");
+    }
+
+    @Test
+    void givenTemplateWithTimestampAsEpoch_whenApplyValue_thenReplaced() {
+        Offset offset = Offset.of(ImmutableMap.of("timestamp", Instant.parse("2020-01-01T00:00:00Z")));
+        assertThat(factory.create("${offset.timestamp?datetime.iso?long}").apply(offset)).isEqualTo("1577836800000");
     }
 }

--- a/kafka-connect-http/src/test/java/com/github/castorm/kafka/connect/http/request/template/freemarker/FreeMarkerTemplateFactoryTest.java
+++ b/kafka-connect-http/src/test/java/com/github/castorm/kafka/connect/http/request/template/freemarker/FreeMarkerTemplateFactoryTest.java
@@ -24,6 +24,8 @@ import com.github.castorm.kafka.connect.http.model.Offset;
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
+
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,5 +42,17 @@ class FreeMarkerTemplateFactoryTest {
     void givenTemplate_whenApplyValue_thenReplaced() {
         Offset offset = Offset.of(ImmutableMap.of("key", "offset1"));
         assertThat(factory.create("template ${offset.key}").apply(offset)).isEqualTo("template offset1");
+    }
+
+    @Test
+    void givenTemplateWithTimestampAsString_whenApplyValue_thenReplaced() {
+        Offset offset = Offset.of(ImmutableMap.of("timestamp", Instant.parse("2020-01-01T00:00:00Z")));
+        assertThat(factory.create("${offset.timestamp}").apply(offset)).isEqualTo("2020-01-01T00:00:00Z");
+    }
+
+    @Test
+    void givenTemplateWithTimestampAsEpoch_whenApplyValue_thenReplaced() {
+        Offset offset = Offset.of(ImmutableMap.of("timestamp", Instant.parse("2020-01-01T00:00:00Z")));
+        assertThat(factory.create("${offset.timestamp?datetime.iso?long}").apply(offset)).isEqualTo("1577836800000");
     }
 }


### PR DESCRIPTION
This is a proposal to improve documentation and user experience related to #73 

Main changes being:
- Documentation makes explicit the format of `${offset.timestamp}` on FreeMarker templates.
- FreeMarker templates use "computer" number representation by default, enabling epoch representation like this: ``${offset.timestamp?datetime.iso?long}``
- Elasticsearch example is updated to properly use this property.