### PR TITLE
Fix NPE when confirmationWindow is not initialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ to be included in the `HttpRequest`.
 >     *   `com.github.castorm.kafka.connect.http.auth.BasicHttpAuthenticator`
 
 #### Authenticating with `ConfigurableHttpAuthenticator`
-Allows selecting the athentication type via configuration property
+Allows selecting the authentication type via configuration property
 
 > ##### `http.auth.type`
 > Type of authentication
@@ -304,7 +304,7 @@ Allows selecting the athentication type via configuration property
 > *   Default: `None`
 
 #### Authenticating with `BasicHttpAuthenticator`
-Allows selecting the athentication type via configuration property
+Allows selecting the authentication type via configuration property
 
 > ##### `http.auth.user`
 > *   Type: `String`
@@ -570,6 +570,34 @@ Assumptions:
 ```bash
 mvn package
 ```
+### Debugging
+
+_These instructions are phrased in terms of the steps needed when using IntelliJ,
+but other integrated development environments are likely to be similar._
+
+Point the Kafka stand-alone **plugin.path** at the module compile **Output path**.
+Assuming you are using the default Maven project import,
+this is the **./target** directory, so the **config/connect-standalone.properties** file would contain the line
+```bash
+plugin.path=<directory where git clone was executed>/kafka-connect-http/kafka-connect-http/target
+```
+In the **Run/Debug Configurations** dialog, create a new **Remote JVM Debug** configuration with the mode **Attach to remote JVM**.
+When remote debugging, some Java parameters need to be specified when the program is executed.
+Fortunately there are hooks in the Kafka shell scripts to accommodate this.
+The **Remote JVM Debug** configuration specifies the needed **Command line arguments for remote JVM**.
+In the terminal console where you execute the connect command line, define **KAFKA_DEBUG** and **JAVA_DEBUG_OPTS** as:
+```bash
+export KAFKA_DEBUG=true
+export JAVA_DEBUG_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
+```
+Place a suitable breakpoint in the kafka-connect-http code, e.g. in `HttpSourceTask.start()`, and launch the standalone connect program:
+```bash
+bin/connect-standalone.sh config/connect-standalone.properties plugins/<kafka-connect-http properties file>
+```
+Click the Debug icon in IntelliJ and ensure
+the debugger console says `Connected to the target VM, address: 'localhost:5005', transport: 'socket'`
+and the breakpoint you placed becomes checked.
+The program should now break when the breakpoint is hit.
 ### Running the tests
 ```bash
 mvn test

--- a/kafka-connect-http/pom.xml
+++ b/kafka-connect-http/pom.xml
@@ -11,6 +11,10 @@
     <artifactId>kafka-connect-http</artifactId>
     <name>Kafka Connect HTTP</name>
 
+    <properties>
+        <env.GPG_PASSPHRASE>bogus</env.GPG_PASSPHRASE>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -196,6 +200,7 @@
                         </executions>
                     </plugin>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
                         <version>3.2.1</version>
                         <executions>
@@ -208,6 +213,7 @@
                         </executions>
                     </plugin>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>3.2.0</version>
                         <configuration>

--- a/kafka-connect-http/pom.xml
+++ b/kafka-connect-http/pom.xml
@@ -11,10 +11,6 @@
     <artifactId>kafka-connect-http</artifactId>
     <name>Kafka Connect HTTP</name>
 
-    <properties>
-        <env.GPG_PASSPHRASE>bogus</env.GPG_PASSPHRASE>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/HttpSourceTask.java
+++ b/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/HttpSourceTask.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static com.github.castorm.kafka.connect.common.VersionUtils.getVersion;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
@@ -66,7 +67,7 @@ public class HttpSourceTask extends SourceTask {
 
     private SourceRecordFilterFactory recordFilterFactory;
 
-    private ConfirmationWindow<Map<String, ?>> confirmationWindow;
+    private ConfirmationWindow<Map<String, ?>> confirmationWindow = new ConfirmationWindow<>(emptyList());
 
     @Getter
     private Offset offset;
@@ -141,8 +142,6 @@ public class HttpSourceTask extends SourceTask {
 
     @Override
     public void commit() {
-        if (null == confirmationWindow)
-            return;
         offset = confirmationWindow.getLowWatermarkOffset()
                 .map(Offset::of)
                 .orElse(offset);

--- a/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/HttpSourceTask.java
+++ b/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/HttpSourceTask.java
@@ -141,6 +141,8 @@ public class HttpSourceTask extends SourceTask {
 
     @Override
     public void commit() {
+        if (null == confirmationWindow)
+            return;
         offset = confirmationWindow.getLowWatermarkOffset()
                 .map(Offset::of)
                 .orElse(offset);

--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,7 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>3.0.0-M1</version>
                 <configuration>


### PR DESCRIPTION
    For cases where the throttle specifies a long time initially,
    calls from Kafka to HttpSourceTask.commit() result in a NullPointerException
    because the confirmationWindow initialization has not yet completed in HttpSourceTask.poll().
    This adds a simple test and skips the update of offset if this is the case.
    
    A short Debugging section was added to the README.md,
    since this will be a common use-case for new deveopers to the project,
    and some typos were corrected.
    
    A few missing Maven <groupId> tags were added to avoid unresolved components.