### PR TITLE
Support backslash escaped commas in header values.

### DIFF
--- a/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/common/ConfigUtils.java
+++ b/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/common/ConfigUtils.java
@@ -31,18 +31,20 @@ import java.util.stream.Collector;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptySet;
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.mapping;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
-import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Collectors.*;
 import static java.util.stream.IntStream.rangeClosed;
 
 @UtilityClass
 public class ConfigUtils {
 
     public static Map<String, List<String>> breakDownHeaders(String headers) {
-        return breakDownMultiValuePairs(headers, ",", ":");
+        return breakDownMultiValuePairs(headers, "(?<!\\\\),", ":")
+                .entrySet()
+                .stream()
+                .collect(toMap(Map.Entry::getKey, entry ->
+                        entry.getValue().stream().map(value ->
+                                value.replaceAll("\\\\,", ","))
+                                .collect(toList())));
     }
 
     public static Map<String, List<String>> breakDownQueryParams(String queryParams) {
@@ -87,7 +89,7 @@ public class ConfigUtils {
     }
 
     private static Stream<String> breakDownList(String itemList, String splitter) {
-        if (itemList == null || itemList.length() == 0) {
+        if (itemList==null || itemList.length()==0) {
             return Stream.empty();
         }
         return Stream.of(itemList.split(splitter))
@@ -104,14 +106,14 @@ public class ConfigUtils {
 
     private static Set<Integer> parseIntegerRange(String range) {
         String[] rangeString = range.split("\\.\\.");
-        if (rangeString.length == 0 || rangeString[0].length() == 0) {
+        if (rangeString.length==0 || rangeString[0].length()==0) {
             return emptySet();
-        } else if (rangeString.length == 1) {
+        } else if (rangeString.length==1) {
             return asSet(Integer.valueOf(rangeString[0].trim()));
-        } else if (rangeString.length == 2) {
+        } else if (rangeString.length==2) {
             int from = Integer.parseInt(rangeString[0].trim());
             int to = Integer.parseInt(rangeString[1].trim());
-            return (from < to ? rangeClosed(from, to) : rangeClosed(to, from)).boxed().collect(toSet());
+            return (from < to ? rangeClosed(from, to):rangeClosed(to, from)).boxed().collect(toSet());
         }
         throw new IllegalStateException(String.format("Invalid range definition %s", range));
     }

--- a/kafka-connect-http/src/test/java/com/github/castorm/kafka/connect/common/ConfigUtilsTest.java
+++ b/kafka-connect-http/src/test/java/com/github/castorm/kafka/connect/common/ConfigUtilsTest.java
@@ -24,6 +24,8 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
 import java.util.AbstractMap.SimpleEntry;
+import java.util.Arrays;
+import java.util.regex.Pattern;
 
 import static com.github.castorm.kafka.connect.common.ConfigUtils.breakDownHeaders;
 import static com.github.castorm.kafka.connect.common.ConfigUtils.breakDownList;
@@ -62,6 +64,21 @@ class ConfigUtilsTest {
     void whenBreakDownHeadersWithSpaces_thenBrokenDown() {
         assertThat(breakDownHeaders(" Name : Value ")).containsExactly(new SimpleEntry<>("Name", singletonList("Value")));
     }
+
+    @Test
+    void whenBreakDownHeadersWithCommasInValues() {
+        assertThat(breakDownHeaders("Name1:Prefix1\\,Suffix1,Name2:Value2,Name3:Prefix3\\\\,Suffix3"))
+                .contains(new SimpleEntry<>("Name1", singletonList("Prefix1,Suffix1")),
+                        new SimpleEntry<>("Name2", singletonList("Value2")),
+                        new SimpleEntry<>("Name3", singletonList("Prefix3\\,Suffix3")));
+    }
+
+    @Test
+    void whenBreakDownMultiValueHeadersWithCommasInValues() {
+        assertThat(breakDownHeaders("Name1:Prefix1\\,Suffix1,Name1:Prefix2\\,Suffix2"))
+                .containsExactly(new SimpleEntry<>("Name1", asList("Prefix1,Suffix1", "Prefix2,Suffix2")));
+    }
+
 
     @Test
     void whenBreakDownTwoHeaders_thenBrokenDown() {


### PR DESCRIPTION
Allows HTTP header *values* to include embedded commas escaped with backslash (`\,`) per #101.

This was the most obvious choice of escape character and the implementation is about as simple as it gets. You may want to consider other options, such as double comma (I doubt anyone would ever really want two commas in a row?) but anything like that would be a trivial change.

This *only* affects `ConfigUtils.breakDownHeaders()`. I did not push it to a lower level in interest of limiting effects on existing users.