### PR TITLE
Enable handling of null value returned by field defined as response.list.pointer

### DIFF
--- a/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/response/jackson/JacksonSerializer.java
+++ b/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/response/jackson/JacksonSerializer.java
@@ -59,7 +59,12 @@ class JacksonSerializer {
 
     Stream<JsonNode> getArrayAt(JsonNode node, JsonPointer pointer) {
         JsonNode array = getRequiredAt(node, pointer);
-        return array.isArray() ? stream(array.spliterator(), false) : Stream.of(array);
+        if (array.isArray()) {
+            return stream(array.spliterator(), false);
+        } else if (array.isNull()) {
+            return Stream.empty();
+        }
+        return Stream.of(array);
     }
 
     private static JsonNode getRequiredAt(JsonNode body, JsonPointer recordsPointer) {

--- a/kafka-connect-http/src/test/java/com/github/castorm/kafka/connect/http/response/jackson/JacksonSerializerTest.java
+++ b/kafka-connect-http/src/test/java/com/github/castorm/kafka/connect/http/response/jackson/JacksonSerializerTest.java
@@ -33,12 +33,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.io.IOException;
 
 import static com.fasterxml.jackson.core.JsonPointer.compile;
-import static com.github.castorm.kafka.connect.http.response.jackson.JacksonSerializerTest.Fixture.array;
-import static com.github.castorm.kafka.connect.http.response.jackson.JacksonSerializerTest.Fixture.deserialize;
-import static com.github.castorm.kafka.connect.http.response.jackson.JacksonSerializerTest.Fixture.item1;
-import static com.github.castorm.kafka.connect.http.response.jackson.JacksonSerializerTest.Fixture.item1Json;
-import static com.github.castorm.kafka.connect.http.response.jackson.JacksonSerializerTest.Fixture.item2;
-import static com.github.castorm.kafka.connect.http.response.jackson.JacksonSerializerTest.Fixture.itemArray;
+import static com.github.castorm.kafka.connect.http.response.jackson.JacksonSerializerTest.Fixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
@@ -83,6 +78,11 @@ class JacksonSerializerTest {
     }
 
     @Test
+    void whenGetNullAtPointerItems_thenNoItem() {
+        assertThat(serializer.getArrayAt(deserialize(itemArrayNull), compile("/items"))).isEmpty();
+    }
+
+    @Test
     void whenGetObjectAtRoot_thenRoot() {
         assertThat(serializer.getObjectAt(deserialize(item1), compile("/"))).isEqualTo(deserialize(item1));
     }
@@ -99,6 +99,7 @@ class JacksonSerializerTest {
         String item2 = "{\"k2\":\"v2\"}";
         String array = "[" + item1 + "," + item2 + "]";
         String itemArray = "{\"items\":[" + item1 + "," + item2 + "]}";
+        String itemArrayNull = "{\"items\":null}";
 
         @SneakyThrows
         static JsonNode deserialize(String body) {

--- a/kafka-connect-http/src/test/java/com/github/castorm/kafka/connect/http/response/jackson/JacksonSerializerTest.java
+++ b/kafka-connect-http/src/test/java/com/github/castorm/kafka/connect/http/response/jackson/JacksonSerializerTest.java
@@ -33,7 +33,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.io.IOException;
 
 import static com.fasterxml.jackson.core.JsonPointer.compile;
-import static com.github.castorm.kafka.connect.http.response.jackson.JacksonSerializerTest.Fixture.*;
+import static com.github.castorm.kafka.connect.http.response.jackson.JacksonSerializerTest.Fixture.array;
+import static com.github.castorm.kafka.connect.http.response.jackson.JacksonSerializerTest.Fixture.deserialize;
+import static com.github.castorm.kafka.connect.http.response.jackson.JacksonSerializerTest.Fixture.item1;
+import static com.github.castorm.kafka.connect.http.response.jackson.JacksonSerializerTest.Fixture.item1Json;
+import static com.github.castorm.kafka.connect.http.response.jackson.JacksonSerializerTest.Fixture.item2;
+import static com.github.castorm.kafka.connect.http.response.jackson.JacksonSerializerTest.Fixture.itemArray;
+import static com.github.castorm.kafka.connect.http.response.jackson.JacksonSerializerTest.Fixture.itemArrayNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 


### PR DESCRIPTION
I use this connector to query records via an API, which returns them as elements of an array. The name of this field in the returned Json is `items`. Therefore I set the configuration `response.list.pointer: /items`.
As long as there are records to return, everything works as expected and the connector publishes them into a Kafka topic.

```
{
  "items": [
    {
      "entity_id": 1,
      "status": "pending"
    },
    {
      "entity_id": 2,
      "status": "pending"
    }
  ]
}

```

However, unfortunately, if there is nothing to return, this API does not return an empty array, but `null` as value of the field `items`. 

```
{
  "items": null
}
```

In this case the connector does not work anymore and throws an exception. The reason basically is that this connector in case of a `null` value returns a `Stream<JsonNode>` with a single `null` value.

I fixed this by returning an empty `Stream<JsonNode>` in case the value is `null`. With this small fix for me everything works as expected.

I know that returning `null` instead of an empty array in the Json response is not best practice, but I cannot change this API and must accept what I get.

Therefore it would be create if you could check that I did not break something else and if it would be possible to merge this fix into your code.

Thanks.