### PR TITLE
Added support for auth token endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ buildNumber.properties
 HttpSourceTaskHarnessTest.java
 .DS_Store
 .java-version
+.project
+.settings
+.factorypath
+.classpath
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM confluentinc/cp-kafka-connect-base
+COPY kafka-connect-http/target/ /opt/connectors/kafka-connect-http/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,80 @@
+version: "3.8"
+services:
+  connect:
+    build: .
+    ports:
+      - "8083:8083"
+    environment:
+      CONNECT_BOOTSTRAP_SERVERS: 'broker:29092'
+      CONNECT_REST_ADVERTISED_HOST_NAME: connect
+      CONNECT_REST_PORT: 8083
+      CONNECT_GROUP_ID: compose-connect-group
+      CONNECT_CONFIG_STORAGE_TOPIC: docker-connect-configs
+      CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: 1
+      CONNECT_OFFSET_FLUSH_INTERVAL_MS: 10000
+      CONNECT_OFFSET_STORAGE_TOPIC: docker-connect-offsets
+      CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: 1
+      CONNECT_STATUS_STORAGE_TOPIC: docker-connect-status
+      CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: 1
+      CONNECT_KEY_CONVERTER: org.apache.kafka.connect.storage.StringConverter
+      CONNECT_VALUE_CONVERTER: io.confluent.connect.avro.AvroConverter
+      CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+      # CLASSPATH required due to CC-2422
+      CLASSPATH: /usr/share/java/monitoring-interceptors/monitoring-interceptors-7.0.0-0.jar
+      CONNECT_PRODUCER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor"
+      CONNECT_CONSUMER_INTERCEPTOR_CLASSES: "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor"
+      CONNECT_PLUGIN_PATH: "/opt/connectors"
+      CONNECT_LOG4J_LOGGERS: org.apache.zookeeper=ERROR,org.I0Itec.zkclient=ERROR,org.reflections=ERROR
+    depends_on:
+        - zookeeper
+        - broker
+        - schema-registry
+  zookeeper:
+    image: confluentinc/cp-zookeeper:6.2.0
+    hostname: zookeeper
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+  broker:
+    image: confluentinc/cp-server:6.2.0
+    hostname: broker
+    container_name: broker
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+      - "9101:9101"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_METRIC_REPORTERS: io.confluent.metrics.reporter.ConfluentMetricsReporter
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_CONFLUENT_BALANCER_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_JMX_PORT: 9101
+      KAFKA_JMX_HOSTNAME: localhost
+      KAFKA_CONFLUENT_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+      CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: broker:29092
+      CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS: 1
+      CONFLUENT_METRICS_ENABLE: 'true'
+      CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
+  schema-registry:
+    image: confluentinc/cp-schema-registry:6.2.0
+    hostname: schema-registry
+    container_name: schema-registry
+    depends_on:
+      - broker
+    ports:
+      - "8081:8081"
+    environment:
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: 'broker:29092'
+      SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081

--- a/kafka-connect-http/pom.xml
+++ b/kafka-connect-http/pom.xml
@@ -74,6 +74,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <scope>test</scope>

--- a/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/auth/ConfigurableHttpAuthenticatorConfig.java
+++ b/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/auth/ConfigurableHttpAuthenticatorConfig.java
@@ -46,16 +46,20 @@ public class ConfigurableHttpAuthenticatorConfig extends AbstractConfig {
     private HttpAuthenticator getAuthenticator(Map<String, ?> originals) {
         switch (HttpAuthenticationType.valueOf(getString(AUTH_TYPE).toUpperCase())) {
             case BASIC:
-                BasicHttpAuthenticator auth = new BasicHttpAuthenticator();
-                auth.configure(originals);
-                return auth;
+                BasicHttpAuthenticator basicAuth = new BasicHttpAuthenticator();
+                basicAuth.configure(originals);
+                return basicAuth;
+            case TOKEN_ENDPOINT:
+                TokenEndpointAuthenticator tokenEndpointAuth = new TokenEndpointAuthenticator();
+                tokenEndpointAuth.configure(originals);
+                return tokenEndpointAuth;
             default:
                 return new NoneHttpAuthenticator();
         }
     }
 
     public static ConfigDef config() {
-        return new ConfigDef()
-                .define(AUTH_TYPE, STRING, HttpAuthenticationType.NONE.name(), MEDIUM, "Authentication Type");
+        return new ConfigDef().define(AUTH_TYPE, STRING, HttpAuthenticationType.NONE.name(), MEDIUM,
+                "Authentication Type");
     }
 }

--- a/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/auth/TokenEndpointAuthenticator.java
+++ b/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/auth/TokenEndpointAuthenticator.java
@@ -1,0 +1,95 @@
+package com.github.castorm.kafka.connect.http.auth;
+
+/*-
+ * #%L
+ * Kafka Connect HTTP
+ * %%
+ * Copyright (C) 2020 - 2021 Cástor Rodríguez
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.castorm.kafka.connect.http.auth.spi.HttpAuthenticator;
+
+import org.apache.kafka.connect.errors.RetriableException;
+
+import org.apache.kafka.connect.errors.ConnectException;
+
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+public class TokenEndpointAuthenticator implements HttpAuthenticator {
+    private final Function<Map<String, ?>, TokenEndpointAuthenticatorConfig> configFactory;
+    private TokenEndpointAuthenticatorConfig config;
+
+    public TokenEndpointAuthenticator() {
+        this(TokenEndpointAuthenticatorConfig::new);
+    }
+
+    public TokenEndpointAuthenticator(Function<Map<String, ?>, TokenEndpointAuthenticatorConfig> configFactory) {
+        this.configFactory = configFactory;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        this.config = configFactory.apply(configs);
+    }
+
+    @Override
+    public Optional<String> getAuthorizationHeader() {
+        String credentialsBody = config.getAuthPayload().value();
+        RequestBody requestBody = RequestBody.create(credentialsBody,
+                MediaType.parse("application/json; charset=utf-8"));
+        String response = execute(requestBody);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        String accessToken;
+        try {
+            accessToken = objectMapper.readTree(response).path(config.getTokenKeyPath()).asText();
+        } catch (JsonProcessingException e) {
+            throw new RetriableException("Error: " + e.getMessage(), e);
+        }
+
+        if (accessToken.isBlank()) {
+            throw new RetriableException("Error: No access token found at " + config.getTokenKeyPath());
+        }
+
+        return Optional.of("Bearer " + accessToken);
+    }
+
+    private String execute(RequestBody requestBody) {
+        OkHttpClient httpClient = new OkHttpClient();
+        try {
+            Request request = new Request.Builder().url(config.getAuthUri()).post(requestBody).build();
+            Response response = httpClient.newCall(request).execute();
+            return response.body().string();
+        } catch (IOException e) {
+            throw new RetriableException("Error: " + e.getMessage(), e);
+        } catch (IllegalArgumentException e) {
+            throw new ConnectException("Error: " + e.getMessage(), e);
+        }
+    }
+
+}

--- a/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/auth/TokenEndpointAuthenticatorConfig.java
+++ b/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/auth/TokenEndpointAuthenticatorConfig.java
@@ -1,0 +1,57 @@
+package com.github.castorm.kafka.connect.http.auth;
+
+/*-
+ * #%L
+ * Kafka Connect HTTP
+ * %%
+ * Copyright (C) 2020 - 2021 Cástor Rodríguez
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.Map;
+
+import lombok.Getter;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.types.Password;
+
+import static org.apache.kafka.common.config.ConfigDef.Importance.HIGH;
+import static org.apache.kafka.common.config.ConfigDef.Type.STRING;
+
+@Getter
+public class TokenEndpointAuthenticatorConfig extends AbstractConfig {
+    private static final String AUTH_URI = "http.auth.uri";
+    private static final String PAYLOAD = "http.auth.payload";
+    private static final String TOKEN_KEY_PATH = "http.auth.tokenkeypath";
+
+    private final String authUri;
+    private final Password authPayload;
+    private final String tokenKeyPath;
+
+    public TokenEndpointAuthenticatorConfig(Map<?, ?> originals) {
+        super(config(), originals);
+        authUri = getString(AUTH_URI);
+        authPayload = getPassword(PAYLOAD);
+        tokenKeyPath = getString(TOKEN_KEY_PATH);
+
+    }
+
+    public static ConfigDef config() {
+        return new ConfigDef().define(PAYLOAD, ConfigDef.Type.PASSWORD, "", HIGH, "Auth payload JSON")
+                .define(TOKEN_KEY_PATH, STRING, "access_token", HIGH, "Auth request response token key")
+                .define(AUTH_URI, STRING, "", HIGH, "Auth endpoint");
+    }
+
+}

--- a/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/auth/spi/HttpAuthenticationType.java
+++ b/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/auth/spi/HttpAuthenticationType.java
@@ -21,5 +21,5 @@ package com.github.castorm.kafka.connect.http.auth.spi;
  */
 
 public enum HttpAuthenticationType {
-    NONE, BASIC
+    NONE, BASIC, TOKEN_ENDPOINT
 }

--- a/kafka-connect-http/src/test/java/com/github/castorm/kafka/connect/http/auth/TokenEndpointAuthenticatorConfigTest.java
+++ b/kafka-connect-http/src/test/java/com/github/castorm/kafka/connect/http/auth/TokenEndpointAuthenticatorConfigTest.java
@@ -1,0 +1,70 @@
+package com.github.castorm.kafka.connect.http.auth;
+
+/*-
+ * #%L
+ * Kafka Connect HTTP
+ * %%
+ * Copyright (C) 2020 CastorM
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.kafka.common.config.types.Password;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TokenEndpointAuthenticatorConfigTest {
+
+    @Test
+    void whenNoPayload_thenDefault() {
+        assertThat(config(emptyMap()).getAuthPayload()).isEqualTo(new Password(""));
+    }
+
+    @Test
+    void whenPayload_thenInitialized() {
+        assertThat(config(ImmutableMap.of("http.auth.payload", "{\"foo\": \"bar\"}")).getAuthPayload())
+                .isEqualTo(new Password("{\"foo\": \"bar\"}"));
+    }
+
+    @Test
+    void whenAuthEndpoint_thenInitialized() {
+        assertThat(config(ImmutableMap.of("http.auth.uri", "http://lol/login")).getAuthUri())
+                .isEqualTo("http://lol/login");
+    }
+
+    @Test
+    void whenNoAuthEndpoint_thenDefault() {
+        assertThat(config(emptyMap()).getAuthUri()).isEmpty();
+    }
+
+    @Test
+    void whenTokenKeyPath_thenInitialized() {
+        assertThat(config(ImmutableMap.of("http.auth.tokenkeypath", "path.to.token")).getTokenKeyPath())
+                .isEqualTo("path.to.token");
+    }
+
+    @Test
+    void whenNoTokenKeyPath_thenDefault() {
+        assertThat(config(emptyMap()).getTokenKeyPath()).isEqualTo("access_token");
+    }
+
+    private static TokenEndpointAuthenticatorConfig config(Map<String, String> config) {
+        return new TokenEndpointAuthenticatorConfig(config);
+    }
+}

--- a/kafka-connect-http/src/test/java/com/github/castorm/kafka/connect/http/auth/TokenEndpointAuthenticatorTest.java
+++ b/kafka-connect-http/src/test/java/com/github/castorm/kafka/connect/http/auth/TokenEndpointAuthenticatorTest.java
@@ -1,0 +1,96 @@
+package com.github.castorm.kafka.connect.http.auth;
+
+/*-
+ * #%L
+ * Kafka Connect HTTP
+ * %%
+ * Copyright (C) 2020 CastorM
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class TokenEndpointAuthenticatorTest {
+
+    @Mock
+    TokenEndpointAuthenticatorConfig config;
+    TokenEndpointAuthenticator authenticator;
+    MockWebServer webServer;
+    MockResponse response;
+
+    @BeforeEach
+    void setUp() {
+        authenticator = new TokenEndpointAuthenticator(__ -> config);
+        webServer = new MockWebServer();
+        response = new MockResponse().addHeader("Content-Type", "application/json; charset=utf-8").setBody(
+                "{\"accessToken\":\"someRandomJwtTokenHeader.someLongTokenIThatProbablyDoesntLookLikeThisAtAll\",\"expiresIn\":123456}");
+    }
+
+    @Test
+    void whenCredentials_thenAccessToken() {
+
+        webServer.enqueue(response);
+
+        given(config.getAuthUri()).willReturn(webServer.url("/Auth").toString());
+        given(config.getTokenKeyPath()).willReturn("accessToken");
+        given(config.getAuthPayload())
+                .willReturn(new Password("{  \"login\": \"myUser\",  \"password\": \"myPassword\"}"));
+
+        authenticator.configure(emptyMap());
+
+        assertThat(authenticator.getAuthorizationHeader().toString())
+                .contains("Bearer someRandomJwtTokenHeader.");
+    }
+
+    @Test
+    void whenNoCredentials_thenException() {
+
+        given(config.getAuthUri()).willReturn("http://google.com/");
+        given(config.getAuthPayload()).willReturn(new Password(""));
+
+        authenticator.configure(emptyMap());
+
+        assertThatThrownBy(() -> authenticator.getAuthorizationHeader()).isInstanceOf(ConnectException.class);
+
+    }
+
+    @Test
+    void whenInvalidUri_thenException() {
+
+        given(config.getAuthUri()).willReturn("this makes no sense");
+        given(config.getAuthPayload())
+                .willReturn(new Password("{  \"login\": \"myUser\",  \"password\": \"myPassword\"}"));
+
+        authenticator.configure(emptyMap());
+
+        assertThatThrownBy(() -> authenticator.getAuthorizationHeader()).isInstanceOf(ConnectException.class);
+
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,11 @@
                 <version>${okhttp.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>mockwebserver</artifactId>
+                <version>${okhttp.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson.version}</version>


### PR DESCRIPTION
This adds the `TokenEndpointAuthenticator` class, which can be used to retrieve an auth token by making a POST-request to an HTTP endpoint before each poll. It is not the most efficient approac possible, as these types of tokens have a life span which is typically far larger than the desired polling interval, but at least it is a start and it can be expanded later.

These config attributes were added:
- "http.auth.uri": The full URI for the token endpoint
- "http.auth.payload": Payload for the token request (ie. some escaped json)
- "http.auth.tokenkeypath": Where in the returned payload to retreive the token from

Here is an example of a connector which also shows the three new config parameters added:
```
{
    "name": "sertica-voyage-reports.http.source",
    "config": {
        "connector.class": "com.github.castorm.kafka.connect.http.HttpSourceConnector",
        "tasks.max": "1",
        "http.offset.initial": "timestamp=2020-05-08T07:55:44Z",
        "http.request.url": "{{uri}}/VoyageReports/search",
        "http.request.headers": "accept: text/plain,Content-Type: application/json",
        "http.request.body": "{  \"distinct\": true,  \"includeSubObjects\": true,  \"criteria\": [    {      \"field\": \"updateDate\",      \"operator\": \"GreaterThan\",      \"values\": [        \"${offset.timestamp?datetime.iso}\"      ]    }  ],  \"sorting\": [    {      \"field\": \"updateDate\",      \"direction\": \"Asc\"    }  ]}",
        "http.request.method": "POST",
        "http.auth.type": "Token_Endpoint", # Token_Endpoint option was added in this PR
        "http.auth.uri": "http://dkcph-pmstapp1.dk.dfds.root:9001/Auth", # This was added in this PR
        "http.auth.payload": "{\"login\": \"mamor\", \"password\": \"{{password}}\"}", # This was added in this PR
        "http.auth.tokenkeypath": "accessToken", # This was added in this PR
        "http.response.list.pointer": "/",
        "http.response.record.offset.pointer": "key=/voyageReportNo, timestamp=/updateDate",
        "http.response.record.timestamp.parser.zpme": "UTC",
        "http.response.record.timestamp.parser": "com.github.castorm.kafka.connect.http.response.timestamp.NattyTimestampParser",
        "http.timer.interval.millis": "30000",
        "http.timer.catchup.interval.millis": "1000",
        "kafka.topic": "sertica-voyage-reports-cdc"
    }
}
```

I have also added a dev-dependency (mockhttpserver) to be able to test this functionality with okhttp calls mocked.

What do you think?