### PR TITLE
Fix: adding non-parameters constructor

### DIFF
--- a/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/response/timestamp/RegexTimestampParser.java
+++ b/kafka-connect-http/src/main/java/com/github/castorm/kafka/connect/http/response/timestamp/RegexTimestampParser.java
@@ -37,6 +37,10 @@ public class RegexTimestampParser implements TimestampParser {
   private final Function<Map<String, ?>, RegexTimestampParserConfig> configFactory;
   private Pattern pattern;
   private TimestampParser delegate;
+  
+  public RegexTimestampParser() {
+    this(RegexTimestampParserConfig::new);
+  }
 
   @Override
   public Instant parse(String timestamp) {


### PR DESCRIPTION
After using the RegexTimestampParser, such error was returned:

KafkaException: Could not find a public no-argument constructor for com.github.castorm.kafka.connect.http.response.timestamp.RegexTimestampParser

The RegexTimestampParser indeed didn't have a no-argument constructor, contrary to other files, so I've added the constructor. It works fine now.